### PR TITLE
Fixed index.js RouterViewport.svelte export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { writable, get as getStore } from 'svelte/store'
 
-export { default as RouterViewport } from './RouterViewport'
+export { default as RouterViewport } from './RouterViewport.svelte'
 
 function isValidTokenChar(code) {
 	// a-z


### PR DESCRIPTION
When I try to run the plugin, the Rollup compiler gives me this error:

`[!] Error: Could not resolve './RouterViewport' from node_modules\@danielsharkov\svelte-router\src\index.js
Error: Could not resolve './RouterViewport' from node_modules\@danielsharkov\svelte-router\src\index.js
    at error (C:\Users\beerf\Desktop\svelte-app\node_modules\rollup\dist\rollup.js:9408:30)
    at ModuleLoader.handleMissingImports (C:\Users\beerf\Desktop\svelte-app\node_modules\rollup\dist\rollup.js:16442:17)
    at ModuleLoader.<anonymous> (C:\Users\beerf\Desktop\svelte-app\node_modules\rollup\dist\rollup.js:16493:26)
    at Generator.next (<anonymous>)
    at fulfilled (C:\Users\beerf\Desktop\svelte-app\node_modules\rollup\dist\rollup.js:15466:28)`

The reason for this is, that you export the `RouterViewport.svelte` with 

`export { default as RouterViewport } from './RouterViewport'`

but this doesn't work by default. Maybe it's possible, but by default it would cause an error, because you always have to define the full filename for svelte file imports/exports. So it will be

`export { default as RouterViewport } from './RouterViewport.svelte'`

I changed it on my system, run it, and now it works.